### PR TITLE
[7.x] add support for beats 7.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -79,6 +79,13 @@ suites:
         - "."
     run_list:
     attributes:
+  - name: standard-6x
+    provisioner:
+      playbook: test/integration/standard-6x.yml
+      additional_copy_path:
+        - "."
+    run_list:
+    attributes:
   - name: multi
     provisioner:
       playbook: test/integration/multi.yml

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dependencies
 ------------
 
 - Ansible version > 2.0
-- Beats version >= 1.x
+- Beats version >= 6.x
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported variables are as follows:
 
 - **beat** (*MANDATORY*): Beat product. Supported values are: "filebeat", "metricbeat" & "packetbeat".
 - **beat_conf** (*MANDATORY*): Beat Configuration. Should be defined as a map (see [Example Playbook](#example-playbook))
-- **beats_version** (*Defaults to `6.2.4`*): Beats version. **Beats 7.x is not yet supported**.
+- **beats_version** (*Defaults to `7.0.0`*): Beats version.
 - **version_lock** (*Defaults to `false`*): Locks the installed version if set to true, thus preventing other processes from updating. This will not impact the roles ability to update the beat on subsequent runs (it unlocks and re-locks if required).
 - **use_repository** (*Defaults to `true`*): Use elastic repo for yum or apt if true. If false, a custom custom_package_url must be provided.
 - **start_service** (*Defaults to `true`*): service will be started if true, false otherwise.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for beats
 
-beats_version: 6.2.4
+beats_version: 7.0.0
 version_lock: false
 use_repository: true
 start_service: true

--- a/tasks/beats-debian.yml
+++ b/tasks/beats-debian.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: "Debian - check that beats {{ beats_major_version }} version exists"
-  assert:
-    that:
-      "repo_urls[beats_major_version] is defined"
-
 - name: Debian - Ensure apt-transport-https is installed
   apt: name=apt-transport-https state=present cache_valid_time=86400
   when: use_repository
@@ -16,7 +11,7 @@
   when: use_repository
 
 - name: Debian - add beats repository
-  apt_repository: repo="deb {{ repo_urls[beats_major_version] }} stable main" state=present
+  apt_repository: repo="deb {{ repo_url }} stable main" state=present
   when: use_repository
 
 - name: Debian - unhold {{beat}} version for install

--- a/tasks/beats-redhat.yml
+++ b/tasks/beats-redhat.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: "RedHat - check that beats {{ beats_major_version }} version exists"
-  assert:
-    that:
-      "repo_urls[beats_major_version] is defined"
-
 - name: Ensure libselinux-python on CentOS 6.x
   yum: name=libselinux-python state=present update_cache=yes
   when: ( ansible_distribution == "CentOS" ) and ( ansible_distribution_major_version == "6" )

--- a/templates/beats.repo.j2
+++ b/templates/beats.repo.j2
@@ -1,6 +1,6 @@
 [beats]
 name=Elastic Beats Repository
-baseurl={{ repo_urls[beats_major_version] }}
+baseurl={{ repo_url }}
 enabled=1
 gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
 gpgcheck=1

--- a/test/integration/multi.yml
+++ b/test/integration/multi.yml
@@ -2,7 +2,7 @@
 - name: wrapper playbook for kitchen testing "beats"
   hosts: localhost
   roles:
-    - { role: "ansible-beats", beat: "filebeat", beat_conf: { "filebeat": {"prospectors":[{"paths":["/var/log/*.log"],"input_type":"log"}], "registry_file": "/var/lib/filebeat/registry"} } }
+    - { role: "ansible-beats", beat: "filebeat", beat_conf: {"filebeat": {"inputs":[{"paths":["/var/log/*.log"],"type":"log"}]} } }
     - { role: "ansible-beats", beat: "metricbeat", beat_conf: { "metricbeat.modules": [{"module": "system", "metricsets": ["cpu", "filesystem", "network", "process"], "enabled": true, "period": "10s", "processes":[".*"], "cpu_ticks": false } ] } }
   vars:
     use_repository: "true"

--- a/test/integration/standard-6x.yml
+++ b/test/integration/standard-6x.yml
@@ -1,0 +1,8 @@
+---
+- name: wrapper playbook for kitchen testing "beats"
+  hosts: localhost
+  roles:
+    - { role: "ansible-beats", beat: "filebeat", beat_conf: {"filebeat": {"prospectors":[{"paths":["/var/log/*.log"],"input_type":"log"}], "registry_file": "/var/lib/filebeat/registry"} } }
+  vars:
+    beats_version: 6.7.1
+    use_repository: "true"

--- a/test/integration/standard-6x/serverspec/default_spec.rb
+++ b/test/integration/standard-6x/serverspec/default_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'Standard Tests' do
+
+  describe service('filebeat') do
+    it { should be_running }
+  end
+
+  describe package('filebeat') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/filebeat/filebeat.yml') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+  end
+
+  describe file('/etc/filebeat/filebeat.yml') do
+    it { should contain 'filebeat:' }
+    it { should contain 'logging:' }
+    it { should contain 'output:' }
+  end
+
+  describe file('/etc/init.d/filebeat') do
+    it { should exist }
+  end
+
+  if os[:family] == 'redhat'
+    describe command('yum versionlock list | grep filebeat') do
+      its(:stdout) { should_not match /filebeat/ }
+    end
+  elsif ['debian', 'ubuntu'].include?(os[:family])
+    describe command('sudo apt-mark showhold | grep filebeat') do
+      its(:stdout) { should_not match /filebeat/ }
+    end
+  end
+
+end
+

--- a/test/integration/standard.yml
+++ b/test/integration/standard.yml
@@ -2,6 +2,6 @@
 - name: wrapper playbook for kitchen testing "beats"
   hosts: localhost
   roles:
-    - { role: "ansible-beats", beat: "filebeat", beat_conf: {"filebeat": {"prospectors":[{"paths":["/var/log/*.log"],"input_type":"log"}],"registry_file": "/var/lib/filebeat/registry"} } }
+    - { role: "ansible-beats", beat: "filebeat", beat_conf: {"filebeat": {"inputs":[{"paths":["/var/log/*.log"],"type":"log"}]} } }
   vars:
     use_repository: "true"

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -8,5 +8,6 @@ OS:
   - centos-7
 TEST_TYPE:
   - standard
+  - standard-6x
   - multi
   - config

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,8 +2,4 @@
 
 default_file: "/etc/default"
 init_script: "/etc/init.d"
-repo_urls:
-  "1.x": "http://packages.elastic.co/beats/apt"
-  "5.x": "https://artifacts.elastic.co/packages/5.x/apt"
-  "6.x": "https://artifacts.elastic.co/packages/6.x/apt"
-  "7.x": "https://artifacts.elastic.co/packages/7.x/apt"
+repo_url: "https://artifacts.elastic.co/packages/{{ beats_major_version }}/apt"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,4 @@ repo_urls:
   "1.x": "http://packages.elastic.co/beats/apt"
   "5.x": "https://artifacts.elastic.co/packages/5.x/apt"
   "6.x": "https://artifacts.elastic.co/packages/6.x/apt"
+  "7.x": "https://artifacts.elastic.co/packages/7.x/apt"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,3 +6,4 @@ repo_urls:
   "1.x": "https://packages.elastic.co/beats/yum/el/$basearch"
   "5.x": "https://artifacts.elastic.co/packages/5.x/yum"
   "6.x": "https://artifacts.elastic.co/packages/6.x/yum"
+  "7.x": "https://artifacts.elastic.co/packages/7.x/yum"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,8 +2,4 @@
 
 default_file: "/etc/sysconfig"
 init_script: "/etc/init.d"
-repo_urls:
-  "1.x": "https://packages.elastic.co/beats/yum/el/$basearch"
-  "5.x": "https://artifacts.elastic.co/packages/5.x/yum"
-  "6.x": "https://artifacts.elastic.co/packages/6.x/yum"
-  "7.x": "https://artifacts.elastic.co/packages/7.x/yum"
+repo_url: "https://artifacts.elastic.co/packages/{{ beats_major_version }}/yum"


### PR DESCRIPTION
This PR add support for beats 7.x

⚠️ beats 6.x is introducing breaking changes in configuration:
- `filebeat.input_types` is replaced by `filebeat.type` (https://github.com/elastic/beats/pull/4294)

⚠️ beats 7.x is introducing breaking changes in configuration:
- `filebeat.prospectors` is replaced by `filebeat.inputs` (https://github.com/elastic/beats/pull/8909)

Kitchen [standard scenario](https://github.com/elastic/ansible-beats/compare/beats-7.x?expand=1#diff-6053bb4c6dcac36bb0d2e2034f229127) is no more compatible with all all major versions.