### PR TITLE
[galaxy] fix role name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,9 @@
 ---
-# handlers file for beats
 
 allow_duplicates: yes
 
 galaxy_info:
+  role_name: beats
   author: Dale McDiarmid
   description: Beats for Linux
   company: "Elastic.co"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,4 +21,8 @@ galaxy_info:
     versions:
     - all
   categories:
-    - system
+    - beats
+    - elastic
+    - elk
+    - logging
+    - monitoring


### PR DESCRIPTION
Galaxy role name is [ansible_beats](https://galaxy.ansible.com/elastic/ansible_beats) since Ansible Galaxy v3.0 no longer perform name calculation by removing `ansible` prefix (https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names).

Also adding some more relevant tags.