### PR TITLE
Support OSS versions of beats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Supported variables are as follows:
 - **beat** (*MANDATORY*): Beat product. Supported values are: "filebeat", "metricbeat" & "packetbeat".
 - **beat_conf** (*MANDATORY*): Beat Configuration. Should be defined as a map (see [Example Playbook](#example-playbook))
 - **beats_version** (*Defaults to `7.0.0`*): Beats version.
+- **beats_enable_xpack** (*Defaults to `true`*): Setting this to `false` causes the OSS version of Beats to be installed.
 - **version_lock** (*Defaults to `false`*): Locks the installed version if set to true, thus preventing other processes from updating. This will not impact the roles ability to update the beat on subsequent runs (it unlocks and re-locks if required).
 - **use_repository** (*Defaults to `true`*): Use elastic repo for yum or apt if true. If false, a custom custom_package_url must be provided.
 - **start_service** (*Defaults to `true`*): service will be started if true, false otherwise.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for beats
 
-beats_version: 7.0.0
+beats_version: 7.1.1
 version_lock: false
 use_repository: true
 start_service: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 
 beats_version: 7.1.1
 version_lock: false
-use_oss: false
 use_repository: true
 start_service: true
 restart_on_change: true
@@ -12,3 +11,4 @@ logging_conf: {"files":{"rotateeverybytes":10485760}}
 output_conf: {"elasticsearch":{"hosts":["localhost:9200"]}}
 beats_pid_dir: "/var/run"
 beats_conf_dir: "/etc/{{beat}}"
+beats_enable_xpack: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 
 beats_version: 7.1.1
 version_lock: false
+use_oss: false
 use_repository: true
 start_service: true
 restart_on_change: true

--- a/tasks/beats-param-check.yml
+++ b/tasks/beats-param-check.yml
@@ -7,3 +7,7 @@
   when: beat_conf is not defined
 
 - set_fact: "beats_major_version={{ beats_version[0] }}.x"
+  when: not use_oss
+
+- set_fact: "beats_major_version=oss-{{ beats_version[0] }}.x"
+  when: use_oss

--- a/tasks/beats-param-check.yml
+++ b/tasks/beats-param-check.yml
@@ -7,7 +7,7 @@
   when: beat_conf is not defined
 
 - set_fact: "beats_major_version={{ beats_version[0] }}.x"
-  when: not use_oss
+  when: beats_enable_xpack
 
 - set_fact: "beats_major_version=oss-{{ beats_version[0] }}.x"
-  when: use_oss
+  when: not beats_enable_xpack


### PR DESCRIPTION
This adds a new default variable called `use_oss` that defaults to false. If you set it to `true`, then the OSS package repositories are used. It also bumps the default beats version from `7.0.0` to `7.1.1`.