### PR TITLE
remove unused es_conf_dir variable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,4 @@
 # vars file for beats
 
 beats_package_url: "https://download.elastic.co/beats"
-es_conf_dir: "/etc"
 repo_key: "https://packages.elastic.co/GPG-KEY-elasticsearch"


### PR DESCRIPTION
As es_conf_dir is not used anywhere in the role, we should remove it.
As it conflict with ansible.elasticsearch variable definition, we need to remove it.

fix #31 