### PR TITLE
Add probot config to manage stale issues/pr + GH issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,40 @@
+<!--
+
+** Please read the guidelines below. **
+
+Issues that do not follow these guidelines are likely to be closed.
+
+1.  GitHub is reserved for bug reports and feature requests. The best place to
+    ask a general question is at the Elastic [forums](https://discuss.elastic.co).
+    GitHub is not the place for general questions.
+
+2.  Is this bug report or feature request for a supported OS? If not, it
+    is likely to be closed.  See https://www.elastic.co/support/matrix#show_os
+
+3.  Please fill out EITHER the feature request block or the bug report block
+    below, and delete the other block.
+
+-->
+
+<!-- Feature request -->
+
+**Describe the feature**:
+
+<!-- Bug report -->
+
+**Beats product**:
+
+**Beats version**
+
+**Role version**:  (If using master please specify github sha)
+
+**OS version** (`uname -a` if on a Unix-like system):
+
+**Description of the problem including expected versus actual behaviour**:
+
+**Playbook**:
+Please specify the full playbook used to reproduce this issue.
+
+**Provide logs from Ansible**:
+
+**Beats logs if relevant**:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+---
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an stale issue is closed
+daysUntilClose: 30
+
+# Label to use when marking an issue as stale
+staleLabel: triage/stale
+
+issues:
+  # Comment to post when marking an issue as stale.
+  markComment: |-
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Comment to post when closing a stale issue.
+  closeComment: |-
+    This issue has been automatically closed because it has not had recent
+    activity since being marked as stale.
+
+pulls:
+  # Comment to post when marking a PR as stale.
+  markComment: |-
+    This PR has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+    To track this PR (even if closed), please open a corresponding issue if one does not already exist.
+  # Comment to post when closing a stale PR.
+  closeComment: |-
+    This PR has been automatically closed because it has not had recent
+    activity since being marked as stale.
+    Please reopen when work resumes.


### PR DESCRIPTION
This PR add [Probot](https://probot.github.io/) configuration to manage stale issues/PR:

- Issues / PR will be marked as stale (with a `triage/stale` label) after 90 days without any activity.
- Stale issues / PR will be closed automatically after 30 days without any activity.

Also add a GitHub Issue template inspired by [elastic/ansible-elasticsearch/.github/issue_template.md](https://github.com/elastic/ansible-elasticsearch/blob/master/.github/issue_template.md)