### PR TITLE
beat config improvements

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,16 +10,16 @@ galaxy_info:
   license: "license (Apache)"
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - 6
-    - 7
-  - name: Debian
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
   galaxy_tags:
     - beats
     - elastic

--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -31,14 +31,14 @@
     state: directory
   when: pid_stat.stat.isdir is not defined or pid_stat.stat.islnk is not defined
 
-#fail if pid and config directories are not links or not directories i.e files
+# fail if pid and config directories are not links or not directories i.e files
 
 - name: Create Config Directory
   file:
     path: '{{ beats_conf_dir }}'
     state: directory
 
-#Copy the default file
+# Copy the default file
 - name: Copy Default File for Instance
   template:
     src: beat.j2
@@ -49,7 +49,7 @@
     group: root
   notify: restart {{ beat }}
 
-#Copy templated config file
+# Copy templated config file
 - name: Copy Configuration File for {{ beat }}
   template:
     src: beat.yml.j2

--- a/tasks/beats.yml
+++ b/tasks/beats.yml
@@ -9,7 +9,7 @@
   include_tasks: beats-redhat.yml
   when: ansible_os_family == 'RedHat'
 
-#Configuration file for beats
+# Configuration file for beats
 - name: Beats configuration
   include_tasks: beats-config.yml
 

--- a/templates/beat.yml.j2
+++ b/templates/beat.yml.j2
@@ -2,10 +2,6 @@
 
 ################### {{beat}} Configuration #########################
 
-{% if bead_additional_conf is defined %}
-{{ bead_additional_conf | to_nice_yaml(indent=2) }}
-{% endif %}
-
 ############################# {{beat}} ######################################
 {{ beat_conf | to_nice_yaml(indent=2) }}
 

--- a/templates/beat.yml.j2
+++ b/templates/beat.yml.j2
@@ -1,7 +1,13 @@
+# {{ ansible_managed }}
+
 ################### {{beat}} Configuration #########################
 
+{% if bead_additional_conf is defined %}
+{{ bead_additional_conf | to_nice_yaml(indent=2) }}
+{% endif %}
+
 ############################# {{beat}} ######################################
-{{beat_conf | to_nice_yaml(indent=2)}}
+{{ beat_conf | to_nice_yaml(indent=2) }}
 
 ###############################################################################
 ############################# Libbeat Config ##################################

--- a/test/integration/config.yml
+++ b/test/integration/config.yml
@@ -1,5 +1,5 @@
 ---
-#Install specific version here
+# Install specific version here
 - name: wrapper playbook for kitchen testing beats
   hosts: localhost
   roles:
@@ -26,19 +26,19 @@
               - 11211
           mysql:
             ports:
-             - 3306
+              - 3306
           pgsql:
             ports:
-             - 5432
+              - 5432
           redis:
             ports:
-             - 6379
+              - 6379
           thrift:
             ports:
-             - 9090
+              - 9090
           mongodb:
             ports:
-             - 27017
+              - 27017
       output_conf:
         elasticsearch:
           hosts: ["localhost:9200"]


### PR DESCRIPTION
In order to offer additional configuration possibilities which we use internally, I have extended the template accordingly by the variable `bead_additional_conf`. So it is possible to create any beat configuration.

Furthermore our lint test showed some bugs which will be fixed with the second commit.

I would be happy about a merge!