### PR TITLE
disable ubuntu-1404 tests

### DIFF
--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -1,6 +1,5 @@
 ---
 OS:
-  - ubuntu-1404
   - ubuntu-1604
   - ubuntu-1804
   - debian-8


### PR DESCRIPTION
Tests on Ubuntu 14.04 are currently broken because of https://github.com/test-kitchen/kitchen-docker/issues/353