### PR TITLE
[doc] fix filebeat example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ The simplest configuration therefore consists of:
     beats_version: 7.5.2
     beat: filebeat
     beat_conf:
-      inputs:
-        - type: log
-          enabled: true
-          paths:
-            - /var/log/*.log
+      filebeat:
+        inputs:
+          - type: log
+            enabled: true
+            paths:
+              - /var/log/*.log
 ```
 
 The above installs Filebeat 7.5.2 on the hosts 'localhost'.


### PR DESCRIPTION
Filebeat example in the README is using the old configuration syntax, this PR fix it.

Related to https://github.com/elastic/ansible-beats/issues/70#issuecomment-579442276