### PR TITLE
Add option for disable the repo installation and lock package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Supported variables are as follows:
 - **beats_version** (*Defaults to `7.6.1`*): Beats version.
 - **version_lock** (*Defaults to `false`*): Locks the installed version if set to true, thus preventing other processes from updating. This will not impact the roles ability to update the beat on subsequent runs (it unlocks and re-locks if required).
 - **use_repository** (*Defaults to `true`*): Use elastic repo for yum or apt if true. If false, a custom custom_package_url must be provided.
+- **beats_add_repository** (*Defaults to `{use_repository}`*): Install elastic repo for yum or apt if true. If false, the present repositories will be used. Useful if you already have beats packages in your repo.
 - **start_service** (*Defaults to `true`*): service will be started if true, false otherwise.
 - **restart_on_change** (*Defaults to `true`*): Changes to configuration or installed versions, will result in a restart if true.
 - **daemon_args** (*Applicable to version 1.x of beats*): Allows run time params to be passed to beats.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ beats_version: 7.6.1
 oss_version: false
 version_lock: false
 use_repository: true
+beats_add_repository: "{{ use_repository }}"
 start_service: true
 restart_on_change: true
 daemon_args: ""

--- a/tasks/beats-debian.yml
+++ b/tasks/beats-debian.yml
@@ -44,7 +44,7 @@
     state: present
   register: apt_key_install
   until: apt_key_install is succeeded
-  when: use_repository | bool
+  when: beats_add_repository | bool
 
 - name: Debian - add beats repository
   become: yes
@@ -53,7 +53,7 @@
     state: present
   register: repo_install
   until: repo_install is succeeded
-  when: use_repository | bool
+  when: beats_add_repository | bool
 
 - name: Debian - unhold {{ beat }} version for install
   become: yes

--- a/tasks/beats-redhat.yml
+++ b/tasks/beats-redhat.yml
@@ -16,7 +16,7 @@
   template:
     src: beats.repo.j2
     dest: /etc/yum.repos.d/beats.repo
-  when: use_repository
+  when: beats_add_repository | bool
 
 - name: RedHat - install yum-version-lock
   become: yes
@@ -24,6 +24,7 @@
     name: yum-plugin-versionlock
     state: present
     update_cache: true
+  when: version_lock | bool
   register: versionlock_install
   until: versionlock_install is succeeded
 
@@ -31,6 +32,7 @@
   become: yes
   shell: yum versionlock delete {{ beat }} || true
   changed_when: false
+  when: version_lock | bool
   tags:
     - skip_ansible_lint
 
@@ -43,7 +45,7 @@
     update_cache: true
   register: beat_install
   until: beat_install is succeeded
-  when: use_repository
+  when: use_repository | bool
   notify: restart the service
 
 - name: RedHat - lock {{ beat }} version
@@ -51,7 +53,7 @@
   shell: >-
     yum versionlock add
     {{ beat }}{% if beats_version is defined and beats_version|length %}-{{ beats_version }}{% endif %}
-  when: version_lock
+  when: version_lock | bool
   changed_when: false
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
Sometimes, we already have repo of elastic deployed on servers.

This PR add the option to disable the addition of repos.

I remove too the installation of yum lock package if it is no needed.