### PR TITLE
add amazonlinux2 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,6 +72,18 @@ platforms:
       run_command: "/usr/sbin/init"
       privileged: true
       use_sudo: false
+  - name: amazonlinux-2
+    driver_config:
+      image: amazonlinux:2
+      provision_command:
+        - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        - yum -y install ansible
+      volume:
+        - <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
+        - /etc # This fixes certain java file actions that check the mount point. Without this adding users fails for some docker storage drivers
+      run_command: "/usr/sbin/init"
+      privileged: true
+      use_sudo: false
 suites:
   - name: standard
     provisioner:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This role provides a generic means of installing Elastic supported Beats
 * Debian 9
 * CentOS 6
 * CentOS 7
+* Amazon Linux 2
 
 ## Usage
 

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -7,6 +7,7 @@ OS:
   - debian-9
   - centos-6
   - centos-7
+  - amazonlinux-2
 TEST_TYPE:
   - standard
   - standard-6x


### PR DESCRIPTION
Amazon Linux 2 support will be added for ansible-elasticsearch in https://github.com/elastic/ansible-elasticsearch/pull/703 thanks to @anisf, so let's add it also to ansible-beats