### PR TITLE
[meta] add slack notifications to CI jobs

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -56,6 +56,3 @@
         timeout: 360
         fail: true
     - timestamps
-    publishers:
-    - email:
-        recipients: infra-root+build@elastic.co

--- a/.ci/jobs/elastic+ansible-beats+master.yml
+++ b/.ci/jobs/elastic+ansible-beats+master.yml
@@ -17,3 +17,10 @@
 
         make setup
         make verify PATTERN=$TEST_TYPE-$OS
+    publishers:
+    - slack:
+      notify-back-to-normal: True
+      notify-every-failure: True
+      room: infra-release-notify
+      team-domain: elastic
+      auth-token-id: release-slack-integration-token


### PR DESCRIPTION
This PR add Slack notifications to Elastic Release team Slack channel for [elastic+ansible-beats+master](https://devops-ci.elastic.co/job/elastic+ansible-beats+master/) test job.