### PR TITLE
[meta] add auth-token-credential-id entry for slack

### DIFF
--- a/.ci/jobs/elastic+ansible-beats+master.yml
+++ b/.ci/jobs/elastic+ansible-beats+master.yml
@@ -24,3 +24,4 @@
         room: infra-release-notify
         team-domain: elastic
         auth-token-id: release-slack-integration-token
+        auth-token-credential-id: release-slack-integration-token


### PR DESCRIPTION
This commit adds a new auth-token-credential-id entry in addition of auth-token-id for slack token.

This is due to a bug in JJB which requires having both entries to prevent having an empty authTokenCredentialId in job config.xml (https://storyboard.openstack.org/#!/story/2007953).