### PR TITLE
Allow users to set beats_major_version

### DIFF
--- a/tasks/beats-param-check.yml
+++ b/tasks/beats-param-check.yml
@@ -17,3 +17,4 @@
 - name: Set beats_major_version
   set_fact:
     beats_major_version: '{% if oss_version %}oss-{% endif %}{{ beats_version.split(".")[0] }}.x'
+  when: beats_major_version is not defined


### PR DESCRIPTION
This is needed for when the user sets beats_version to "", to allow the package manager to keep the package up to date without having to change the beats_version variable everytime ansible is run. This also avoids the complexity of adding a custom_package_url when the user just wants to use the default elastic repo.