### PR TITLE
Remove CentOS 6 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,14 +58,6 @@ platforms:
         - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
         - apt-get update && apt-get -y install ansible
       use_sudo: false
-  - name: centos-6
-    driver_config:
-      image: centos:6
-      privileged: true
-      provision_command:
-        - yum -y install epel-release
-        - yum -y install ansible
-      use_sudo: false
   - name: centos-7
     driver_config:
       image: centos:7

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This role provides a generic means of installing Elastic supported Beats
 * Ubuntu 18.04
 * Debian 8
 * Debian 9
-* CentOS 6
 * CentOS 7
 * CentOS 8
 * Amazon Linux 2

--- a/tasks/beats-redhat.yml
+++ b/tasks/beats-redhat.yml
@@ -1,16 +1,4 @@
 ---
-- name: Ensure libselinux-python on CentOS 6.x
-  become: yes
-  yum:
-    name: libselinux-python
-    state: present
-    update_cache: true
-  register: libselinux_install
-  until: libselinux_install is succeeded
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "6"
-
 - name: Redhat - add beats repository
   become: yes
   template:

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -5,7 +5,6 @@ OS:
   - ubuntu-1804
   - debian-8
   - debian-9
-  - centos-6
   - centos-7
   - centos-8
   - amazonlinux-2


### PR DESCRIPTION
This commit remove CentOS 6 support which is EOL since 2020-11-30.
