### PR TITLE
[meta] fix ansible galaxy install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This role provides a generic means of installing Elastic supported Beats
 Create your Ansible playbook with your own tasks, and include the role beats. You will have to have this repository accessible within the context of playbook.
 
 ```sh
-ansible-galaxy install elastic.beats,7.10.1
+ansible-galaxy install elastic.beats,v7.10.1
 ```
 
 Then create your playbook yaml adding the role beats.


### PR DESCRIPTION
This commit fix the Ansible Galaxy install command to use the new
versioning implemented in 7.10.1 release.

ansible-beats tags are now prefixed by `v` which makes Ansible Galaxy
versions also including this prefix.

Fix #121 