### PR TITLE
Add support for map serialized kibana and dashboard configuration setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Supported variables are as follows:
 - **beats_pid_dir** (*Defaults to `/var/run`*): Location of beats pid file.
 - **beats_conf_dir** (*Defaults to `/etc/{beat}`*): Location of conf directory for beats configuration file.
 - **default_ilm_policy** (*Defaults undefined*): local path to default policy if any custom one is defined
+- **setup_conf** (*Defaults undefined*): Setup of kibana and dashboard configuration. Should be defined as a map . Map is serialized into setup section of beat config.
 
 ### Focus on ILM
 

--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -15,6 +15,12 @@
       shipper: '{{ shipper_conf }}'
   when: shipper_conf is defined
 
+- name: Set beat_setup_conf
+  set_fact:
+    beat_setup_conf:
+      setup: '{{ setup_conf }}'
+  when: setup_conf is defined
+
 - name: Set beat_logging_conf
   set_fact:
     beat_logging_conf:

--- a/templates/beat.yml.j2
+++ b/templates/beat.yml.j2
@@ -13,6 +13,11 @@
 
 {{ beat_output_conf | to_nice_yaml(indent=2) }}
 
+{% if beat_setup_conf is defined %}############################## Setup ##########################################
+
+{{ beat_setup_conf | to_nice_yaml(indent=2) }}
+{% endif %}
+
 {% if shipper_conf is defined %}############################# Shipper #########################################
 
 {{ beat_shipper_conf | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
This adds support for setup configuration (e. g. for kibana.ssl or dashboard).
It is build analogous to shipper conf serialization.