### PR TITLE
Copy ILM policy file with root permission

### DIFF
--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -66,14 +66,22 @@
 
 # Copy default ILM policy file
 - name: Create default policies config directory
+  become: yes
   file:
     path: '{{ beat_conf.setup.ilm.policy_file | dirname }}'
     state: directory
+    mode: 0755
+    owner: root
+    group: root
   when: default_ilm_policy is defined
 
 - name: Copy default ILM policy file for {{ beat }}
+  become: yes
   copy:
     src: '{{default_ilm_policy}}'
     dest: '{{ beat_conf.setup.ilm.policy_file }}'
+    mode: 0644
+    owner: root
+    group: root
   when: default_ilm_policy is defined
   notify: restart the service


### PR DESCRIPTION
This commit update ILM policy file tasks to use root permission, so
we can write policies files to directories with root only permissions
like `/etc/filebeat/` or `/var/lib/filebeat/` for example.

Fix #117
