### PR TITLE
Added support for Beats modules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ logging_conf: {"files":{"rotateeverybytes":10485760}}
 output_conf: {"elasticsearch":{"hosts":["localhost:9200"]}}
 beats_pid_dir: "/var/run"
 beats_conf_dir: "/etc/{{beat}}"
+beats_modules_dir: "/etc/{{beat}}/modules.d"

--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -85,3 +85,15 @@
     group: root
   when: default_ilm_policy is defined
   notify: restart the service
+
+- name: Assert modules.path presence
+  assert:
+    that:
+      - beat_conf.filebeat.config.modules.path is defined
+    fail_msg: 'You need to configure beat_conf.filebeat.config.modules.path for modules to be loaded'
+  when: beat_modules is defined
+
+- name: Set up and configure modules
+  include_tasks: beats-modules.yml
+  with_dict: "{{ beat_modules }}"
+  when: beat_modules is defined

--- a/tasks/beats-modules.yml
+++ b/tasks/beats-modules.yml
@@ -1,0 +1,24 @@
+- name: Disable modules
+  become: yes
+  file:
+    path: "{{ beats_modules_dir }}/{{ item.key }}.yml"
+    state: absent
+  when: item.value.enabled is defined and not item.value.enabled
+  notify: restart the service
+
+- name: Enable modules with default config
+  become: yes
+  copy:
+    remote_src: yes
+    src: "{{ beats_modules_dir }}/{{ item.key }}.yml.disabled"
+    dest: "{{ beats_modules_dir }}/{{ item.key }}.yml"
+  when: (not item.value.enabled is defined or item.value.enabled) and not item.value.config is defined
+  notify: restart the service
+
+- name: Set up modules with custom config
+  become: yes
+  copy:
+    content: "{{ item.value.config | to_nice_yaml(indent=2) }}"
+    dest: "{{ beats_modules_dir }}/{{ item.key }}.yml"
+  when: (not item.value.enabled is defined or item.value.enabled) and item.value.config is defined
+  notify: restart the service


### PR DESCRIPTION
Implemented support for managing Beats modules. For the case of default configuration, it assumes the corresponding module to be present inside the `modules.d` directory.

### Basic usage

#### Enabling modules with custom configuration

Enable the `nginx` module with custom configuration:

```yaml
beat_modules:
  nginx:
    config:
      access:
        enabled: true
        var.paths: ["/var/log/nginx/access.log", "/var/log/nginx/*/access.log"]
      error:
        enabled: true
        var.paths: ["/var/log/nginx/error.log", "/var/log/nginx/*/error.log"]
```

#### Enabling modules with default configuration

Enable the `system` and `redis` modules with default configuration:

```yaml
beat_modules:
  system:
  redis:
```

#### Disabling modules

Disable the `rabbitmq` module:

```yaml
beat_modules:
  rabbitmq:
    enabled: false
```