### PR TITLE
Remove Ubuntu-14.04 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,14 +14,6 @@ provisioner:
   idempotency_test: true
 
 platforms:
-  - name: ubuntu-14.04
-    driver_config:
-      image: ubuntu:14.04
-      privileged: true
-      provision_command:
-        - apt-get update && apt-get install -y software-properties-common && add-apt-repository -y ppa:ansible/ansible
-        - apt-get update && apt-get -y -q install ansible python-apt python-pycurl
-      use_sudo: false
   - name: ubuntu-16.04
     driver_config:
       image: ubuntu:16.04

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This role provides a generic means of installing Elastic supported Beats
 
 **Tested Platforms**
 
-* Ubuntu 14.04
 * Ubuntu 16.04
 * Ubuntu 18.04
 * Ubuntu 20.04

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -1,6 +1,5 @@
 ---
 OS:
-  - ubuntu-1404
   - ubuntu-1604
   - ubuntu-1804
   - ubuntu-2004


### PR DESCRIPTION
Remove support for Ubuntu-14.04

EOL for `Ubuntu.14.04`: April 30th 2019