### PR TITLE
Update metadata reference for CentOS 8

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,8 +12,8 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 6
         - 7
+        - 8
     - name: Debian
       versions:
         - all


### PR DESCRIPTION
CentOS 6 was removed with https://github.com/elastic/ansible-beats/pull/120 so let's update the metadata