### PR TITLE
7.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 7.12.0
+
+* 7.12.0 as default version.
+* 6.8.15 as 6.x tested version
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#138](https://github.com/elastic/ansible-beats/pull/138) | [@jmlrt](https://github.com/jmlrt) | [meta] fix changelog after 7.11.2 release  |
+
+
 ## 7.11.2
 
 * 7.11.2 as default version.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This role provides a generic means of installing Elastic supported Beats
 Create your Ansible playbook with your own tasks, and include the role beats. You will have to have this repository accessible within the context of playbook.
 
 ```sh
-ansible-galaxy install elastic.beats,v7.11.2
+ansible-galaxy install elastic.beats,v7.12.0
 ```
 
 Then create your playbook yaml adding the role beats.
@@ -45,7 +45,7 @@ The simplest configuration therefore consists of:
   roles:
     - role: elastic.beats
   vars:
-    beats_version: 7.11.2
+    beats_version: 7.12.0
     beat: filebeat
     beat_conf:
       filebeat:
@@ -56,11 +56,11 @@ The simplest configuration therefore consists of:
               - /var/log/*.log
 ```
 
-The above installs Filebeat 7.11.2 on the hosts 'localhost'.
+The above installs Filebeat 7.12.0 on the hosts 'localhost'.
 
 **Notes**:
 - Beats default version is described in [`beats_version`](https://github.com/elastic/ansible-beats/blob/master/defaults/main.yml#L4). You can override this variable in your playbook to install another version.
-While we are testing this role only with one 7.x and one 6.x version (respectively [7.11.2](https://github.com/elastic/ansible-beats/blob/master/defaults/main.yml#L4) and [6.8.14](https://github.com/elastic/ansible-beats/blob/master/test/integration/standard-6x.yml#L7) at the time of writing), this role should work with others version also in most cases.
+While we are testing this role only with one 7.x and one 6.x version (respectively [7.12.0](https://github.com/elastic/ansible-beats/blob/master/defaults/main.yml#L4) and [6.8.15](https://github.com/elastic/ansible-beats/blob/master/test/integration/standard-6x.yml#L7) at the time of writing), this role should work with others version also in most cases.
 - Beat product is described in `beat` variable. While currently tested Beats are Filebeat, Metricbeat & Packetbeat, this role should work also with other member of [The Beats Family](https://www.elastic.co/products/beats) in most cases.
 
 ## Testing
@@ -166,7 +166,7 @@ Supported variables are as follows:
 
 - **beat** (*MANDATORY*): Beat product. Supported values are: "filebeat", "metricbeat" & "packetbeat" (others beats from [The Beats Family](https://www.elastic.co/products/beats) should work in most cases but aren't currently tested).
 - **beat_conf** (*MANDATORY*): Beat Configuration. Should be defined as a map.
-- **beats_version** (*Defaults to `7.11.2`*): Beats version.
+- **beats_version** (*Defaults to `7.12.0`*): Beats version.
 - **version_lock** (*Defaults to `false`*): Locks the installed version if set to true, thus preventing other processes from updating. This will not impact the roles ability to update the beat on subsequent runs (it unlocks and re-locks if required).
 - **use_repository** (*Defaults to `true`*): Use elastic repo for yum or apt if true. If false, a custom custom_package_url must be provided.
 - **beats_add_repository** (*Defaults to `{use_repository}`*): Install elastic repo for yum or apt if true. If false, the present repositories will be used. Useful if you already have beats packages in your repo.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for beats
-beats_version: 7.11.2
+beats_version: 7.12.0
 oss_version: false
 version_lock: false
 use_repository: true

--- a/test/integration/standard-6x.yml
+++ b/test/integration/standard-6x.yml
@@ -12,5 +12,5 @@
               input_type: log
           registry_file: /var/lib/filebeat/registry
   vars:
-    beats_version: 6.8.14
+    beats_version: 6.8.15
     use_repository: "true"


### PR DESCRIPTION

## 7.12.0

* 7.12.0 as default version.
* 6.8.15 as 6.x tested version


| PR | Author | Title |
| --- | --- | --- |
| [#138](https://github.com/elastic/ansible-beats/pull/138) | [@jmlrt](https://github.com/jmlrt) | [meta] fix changelog after 7.11.2 release  |

