### PR TITLE
Fix unhold issue with custom deb packages

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company: "Elastic.co"
   issue_tracker_url: https://github.com/elastic/ansible-beats/issues
   license: "license (Apache)"
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:

--- a/tasks/beats-debian.yml
+++ b/tasks/beats-debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Debian - Ensure apt-transport-https is installed
   become: yes
   apt:
@@ -40,7 +39,7 @@
 - name: Debian - Add Beats repository key
   become: yes
   apt_key:
-    url: '{{ elastic_repo_key }}'
+    url: "{{ elastic_repo_key }}"
     state: present
   register: apt_key_install
   until: apt_key_install is succeeded
@@ -49,7 +48,7 @@
 - name: Debian - add beats repository
   become: yes
   apt_repository:
-    repo: 'deb {{ repo_url }} stable main'
+    repo: "deb {{ repo_url }} stable main"
     state: present
   register: repo_install
   until: repo_install is succeeded
@@ -65,6 +64,7 @@
     name: "{{ beat }}"
     selection: "install"
   when: beat in ansible_facts.packages
+  changed_when: false
 
 - name: Debian - Ensure {{ beat }} is installed
   become: yes
@@ -96,13 +96,13 @@
     url: >-
       {% if custom_package_url is defined %}{{ custom_package_url }}{%
         else %}{{ beats_package_url }}/{{ beat }}/{{ beat }}_{{ beats_version }}_{{ os_arch }}.deb{% endif %}
-    dest: '/tmp/{{ beat }}_{{ beats_version }}_{{ os_arch }}.deb'
+    dest: "/tmp/{{ beat }}_{{ beats_version }}_{{ os_arch }}.deb"
     validate_certs: false
   when: not use_repository | bool
 
 - name: Debian - Ensure {{ beat }} is installed from downloaded package
   become: yes
   apt:
-    deb: '/tmp/{{ beat }}_{{ beats_version }}_{{ os_arch }}.deb'
+    deb: "/tmp/{{ beat }}_{{ beats_version }}_{{ os_arch }}.deb"
   when: not use_repository | bool
   notify: restart the service

--- a/tasks/beats-debian.yml
+++ b/tasks/beats-debian.yml
@@ -55,10 +55,16 @@
   until: repo_install is succeeded
   when: beats_add_repository | bool
 
+- name: Debian - Check if {{ beat }}  package is installed
+  package_facts:
+    manager: apt
+
 - name: Debian - unhold {{ beat }} version for install
   become: yes
-  command: apt-mark unhold {{ beat }}
-  changed_when: false
+  dpkg_selections:
+    name: "{{ beat }}"
+    selection: "install"
+  when: beat in ansible_facts.packages
 
 - name: Debian - Ensure {{ beat }} is installed
   become: yes
@@ -74,7 +80,9 @@
 
 - name: Debian - hold {{ beat }} version
   become: yes
-  command: apt-mark hold {{ beat }}
+  dpkg_selections:
+    name: "{{ beat }}"
+    selection: "hold"
   when: version_lock
   changed_when: false
 


### PR DESCRIPTION
This commit fix an issue where unholding package fails when using a
custom package url instead of Elastic repository and beat package isn't
installed yet.

Also replace `apt-mark` shell commands by `dpkg_selections` module.

Fix #83
