### PR TITLE
Backup the existing configuration file

### DIFF
--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -62,6 +62,7 @@
     force: true
     owner: root
     group: root
+    backup: yes
   notify: restart the service
 
 # Copy default ILM policy file


### PR DESCRIPTION
Can be useful to keep a backup of the file in case of rollback