### PR TITLE
Feature keystore

### DIFF
--- a/README_KEYSTORE_SSL.md
+++ b/README_KEYSTORE_SSL.md
@@ -1,0 +1,97 @@
+## Enable Beats Keystore for storing sensitve strings
+To enable this feature set `enable_keystore: true` default is `false`.
+
+Currently ony stores the elasticsearch reserver user password for the `remote_monitoring_user`
+and the password for `beats_writer` users needed for publishing the metrics on the monitoring cluster.
+
+See [Grant privileges and roles needed for publishing ](https://www.elastic.co/guide/en/beats/metricbeat/7.13/privileges-to-publish-events.html)
+```yml
+    remote_monitoring_pass: "{{remote_monitoring_user_pass}}"
+    es_output_pass: "{{beats_mon_user_pass}}"
+    enable_keystore: true
+```	
+These passwords are accessible in the beats configuration file via `nd `"${REMOTE_MONITORING_PASS}"` and  `"${ES_OUTPUT_PASS}"`
+
+## Upload SSL CA files for the monitored and monitoring cluster.
+
+To use this feature set  `es_enable_sll: true` and `es_ssl_upload: true`.
+
+```yml
+    es_enable_sll: true
+    es_ssl_upload: true
+    es_output_ssl_ca: "files/certs/es-output.ca"
+    es_mon_ssl_ca: "files/certs/es-mon.ca"
+```
+### Generate CA files for your Monitorig Cluster and Node that it being monitored
+
+```shell
+openssl s_client -showcerts \
+-connect es1-mon.example.com:9200 \
+</dev/null 2>/dev/null|openssl x509 \
+-outform PEM >es-mon.ca
+```
+
+
+### Sample Playbook
+```yml
+- hosts: 
+  - es-nodes
+  roles:
+    - role: ansible-beats
+  vars:
+    beats_version:  "{{ es_version}}"
+    node_name: "{{hostvars[inventory_hostname].node_name}}"
+    es_host:   "{{ ansible_eth0.ipv4.address }}"
+    remote_monitoring_pass: "{{remote_monitoring_user_pass}}"
+    es_output_pass: "{{beats_mon_user_pass}}"
+    enable_keystore: true
+    es_enable_sll: true
+    es_ssl_upload: true
+    es_output_ssl_ca: "files/certs/es-output.ca"
+    es_mon_ssl_ca: "files/certs/es-mon.ca"
+    beat: metricbeat
+    beat_conf:
+      fields:
+        env: mon
+        node_name: "{{node_name}}"
+        host: "{{es_host}}"
+        cluster: "{{cluster_name}}"
+      name: "{{cluster_name}}-{{node_name}}"
+      tags: ["elk", "es-node","metrics"]
+      metricbeat.modules:
+        - module: elasticsearch
+          xpack.enabled: true
+          period: 10s
+          hosts:
+            - "https://{{es_host}}:9200"
+          username: remote_monitoring_user
+          password: "${REMOTE_MONITORING_PASS}"
+          ssl.verification_mode: certificate
+          ssl.certificate_authorities: "{{es_ssl_certificate_path}}/{{es_mon_ssl_ca |basename}}"
+
+    output_conf:
+        elasticsearch:
+          hosts: "{{elasticsearch_mon_host}}"
+          protocol: "https"
+          username: "beats_user"
+          password: "${ES_OUTPUT_PASS}"
+          ssl.verification_mode: certificate
+          ssl.certificate_authorities: "{{es_ssl_certificate_path}}/{{es_output_ssl_ca |basename}}"
+          loadbalance: true
+          worker: 2
+
+```
+
+### Inventory File
+```shell
+[es-nodes]
+es1 node_name=node-1
+es2 node_name=node-3 
+es3 node_name=node-3
+[es-nodes:vars]
+es_version=7.12.1
+cluster_name=my-cluster
+remote_monitoring_user_pass=changeme
+beats_mon_user_pass=changeme
+elasticsearch_mon_host=["es1-mon.example.com:9200","es2-mon.example.com:9200","es3-mon.example.com:9200"]
+```

--- a/README_KEYSTORE_SSL.md
+++ b/README_KEYSTORE_SSL.md
@@ -95,3 +95,29 @@ remote_monitoring_user_pass=changeme
 beats_mon_user_pass=changeme
 elasticsearch_mon_host=["es1-mon.example.com:9200","es2-mon.example.com:9200","es3-mon.example.com:9200"]
 ```
+
+### Bonus
+Playbook for removing metricbeat
+```yml
+- hosts:  es-nodes
+  tasks:
+    - service:
+        name: metricbeat.service
+        state: stopped
+      become: true  
+    - yum:
+        name: metricbeat
+        state: absent
+      become: true
+    - ansible.builtin.systemd:
+        daemon_reexec: yes
+      become: true  
+    - file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - /etc/metricbeat
+        - /usr/share/metricbeat
+        - /var/lib/metricbeat
+      become: true
+```	  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,13 @@ logging_conf: {"files":{"rotateeverybytes":10485760}}
 output_conf: {"elasticsearch":{"hosts":["localhost:9200"]}}
 beats_pid_dir: "/var/run"
 beats_conf_dir: "/etc/{{beat}}"
+beats_data_dir: "/var/lib/{{beat}}"
+beats_home_dir: "/usr/share/{{beat}}"
+enable_keystore: false
+es_output_pass: ''
+es_output_ssl_ca: ''
+es_mon_ssl_ca: ''
+
+es_enable_sll: false
+es_ssl_upload: false
+es_ssl_certificate_path: "{{ beats_conf_dir }}/certs"

--- a/tasks/beats-keystore.yml
+++ b/tasks/beats-keystore.yml
@@ -1,0 +1,23 @@
+#Create KeyStore
+#- name: Check that {{beat}} Server keystore exists
+#  stat:
+#    path: {{beats_data_dir}}/{{beat}}.keystore"
+#  register: keystore_exists
+#  become: true
+#
+#- name: Create {{beat}} keystore
+#  become: true
+#  shell: " {{beats_home_dir}}/bin/{{beat}} keystore create {{beats_conf_dir}}/{{beat}}.yml --path.data {{beats_data_dir}}"
+#  when:  not keystore_exists.stat.exists
+#  ignore_errors: true
+
+- name: Add Elasticsearch Output Password to Keystore
+  become: true
+  shell: "echo {{ es_output_pass }}| {{beats_home_dir}}/bin/{{beat}} keystore add ES_OUTPUT_PASS --stdin --force -c {{beats_conf_dir}}/{{beat}}.yml --path.data {{beats_data_dir}}"
+  when: es_output_pass and enable_keystore
+
+- name: Add Elasticsearch Remote Monitoring User Pass to Keystore
+  become: true
+  shell: "echo {{ remote_monitoring_pass }}| {{ beats_home_dir }}/bin/{{beat}} keystore add REMOTE_MONITORING_PASS --stdin --force -c {{beats_conf_dir}}/{{beat}}.yml  --path.data {{beats_data_dir}}"
+  when: remote_monitoring_pass and enable_keystore
+

--- a/tasks/beats-ssl
+++ b/tasks/beats-ssl
@@ -1,0 +1,24 @@
+
+- name: Ensure certificate directory exists
+  become: yes
+  file:
+    dest: "{{es_ssl_certificate_path}}"
+    state: directory
+    owner: root
+    group: "{{ es_group }}"
+    mode: "750"
+  when: es_ssl_upload
+  
+
+- name: Upload SSL CA files for monitored  and output ES clusters
+  become: yes
+  copy:
+    src: "{{ item }}"
+    dest: "{{ es_ssl_certificate_path }}/{{ item | basename }}"
+    owner: "{{ root }}"
+    group: "{{ root }}"
+    mode: "640"
+  with_items:
+    - "{{ es_output_ssl_ca }}"
+    - "{{ es_mon_ssl_ca }}"
+  when: es_ssl_upload and es_enable_sll 

--- a/tasks/beats-ssl.yml
+++ b/tasks/beats-ssl.yml
@@ -1,0 +1,24 @@
+
+- name: Ensure certificate directory exists
+  become: yes
+  file:
+    dest: "{{es_ssl_certificate_path}}"
+    state: directory
+    owner: root
+    group: root
+    mode: "750"
+  when: es_ssl_upload
+  
+
+- name: Upload SSL CA files for monitored  and output ES clusters
+  become: yes
+  copy:
+    src: "{{ item }}"
+    dest: "{{ es_ssl_certificate_path }}/{{ item | basename }}"
+    owner: root
+    group: root
+    mode: "640"
+  with_items:
+    - "{{ es_output_ssl_ca }}"
+    - "{{ es_mon_ssl_ca }}"
+  when: es_ssl_upload and es_enable_sll 

--- a/tasks/beats.yml
+++ b/tasks/beats.yml
@@ -9,10 +9,19 @@
   include_tasks: beats-redhat.yml
   when: ansible_os_family == 'RedHat'
 
+#Upload SSL Ca files for ES monitoringing and output
+- name: Upload SSL CA files 
+  include_tasks: beats-ssl.yml
+  when: es_enable_sll and es_ssl_upload
+  
+- name: Enable Beats keystore 
+  include_tasks: beats-keystore.yml
+  when: es_output_pass and enable_keystore
+  
 # Configuration file for beats
 - name: Beats configuration
-  include_tasks: beats-config.yml
-
+  include_tasks: beats-config.yml 
+  
 # Make sure the service is started, and restart if necessary
 - name: Start {{ beat_product }} service
   become: yes


### PR DESCRIPTION
See the README_KEYSTORE_SSL.md file.
This pull request adds support for uploading SSL Certificate Authority files for the output Elasticsearch Cluster and the monitored cluster.
Adds support for beats keystore secrets.