### PR TITLE
fix os_arch computation

### DIFF
--- a/tasks/beats-debian.yml
+++ b/tasks/beats-debian.yml
@@ -89,7 +89,7 @@
 - name: Set os_arch
   set_fact:
     os_arch: >-
-      {{ ansible_architecture == 'x86_64' | ternary('amd64', 'i386') }}
+      {{ (ansible_architecture == 'x86_64') | ternary('amd64', 'i386') }}
 
 - name: Debian - Download {{ beat }} from url
   get_url:


### PR DESCRIPTION
Ternary filter requires parenthesis around the test.
SEE: https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#defining-different-values-for-true-false-null-ternary