### PR TITLE
Remove CentOS 8 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ This role provides a generic means of installing Elastic supported Beats
 * Debian 9
 * Debian 10
 * CentOS 7
-* CentOS 8
 * Amazon Linux 2
 
 ## Usage

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -7,7 +7,6 @@ OS:
   - debian-9
   - debian-10
   - centos-7
-  - centos-8
   - amazonlinux-2
 TEST_TYPE:
   - standard


### PR DESCRIPTION
This commit removes CentOS 8 tests. These tests are now failing because
CentOS 8 is now EOL and it's repositories have been archived.

Source: https://forums.centos.org/viewtopic.php?f=54&t=78708
